### PR TITLE
Small fix to test logging

### DIFF
--- a/test/unittest.h
+++ b/test/unittest.h
@@ -68,6 +68,7 @@ public:
 		static std::string log = "ASSERT FAILED: ";
 		
 		verbose((log + message).c_str());
+		std::cout.flush();
 
 		throw test_exception(message);
 	}
@@ -85,6 +86,7 @@ public:
 
 		static std::string log = "TEST FAILED: ";
 		verbose((log + message).c_str());
+		std::cout.flush();
 
 		throw test_exception(message);
 	}
@@ -160,7 +162,8 @@ struct scenario
 		{
 			std::string failure = log + name + ": FAILED";
 			test::log(failure.c_str());
-			
+			std::cout.flush();
+
 			throw test_exception(failure.c_str());
 		}
 	}


### PR DESCRIPTION
Added calls to flush output stream before crashing the test process on
test failures.
